### PR TITLE
add url to deprecation message

### DIFF
--- a/scripts/make_emperor.py
+++ b/scripts/make_emperor.py
@@ -9,4 +9,4 @@
 
 if __name__ == "__main__":
     print("This script has been deprecated, please see the online "
-          "documentation for more help.")
+          "documentation at\n\thttp://emperor.microbio.me/uno/\n for more help.")


### PR DESCRIPTION
please.

The next person who gets this deprecation message might be spared googling and ending
up on the 0.9 site, which talks only about make_emperor.py
